### PR TITLE
Fix shifted keys not always working in LHES

### DIFF
--- a/include/layout_uk.h
+++ b/include/layout_uk.h
@@ -2,6 +2,8 @@
  * Keyboard layout info moved from the original main file since we are now catering for 2 or more 
  * different layouts. For original info and attribution please see the header in main.cpp
  * 
+ * This layout has been developed and tested against a UK layout Logi K270 Keyboard from the MK270 set.
+ * 
  * @file layout_uk.h
  * @author Martin White
  * @brief Keyboard layout info.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,9 @@ void KbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
 				// of the physical keyboard. An example would be the ^. On a PC keyboard, this is shift 6
 				// but on an X68000 it is unshifted (the ^~ key).
 				Serial.write(SHIFT_SCAN RELEASE); // undo shift
+				delay(25);
 				Serial.write(unshiftKey PRESS);
+				delay(25);
 				Serial.write(SHIFT_SCAN PRESS); // reapply shift
 			}
 			else


### PR DESCRIPTION
It would seem the reason shifted / unshifted keys didn't always work in LHES is an issue of timing. Ideally we would scope out how long the serial write takes to be accepted by the system and create the delay accordingly. For now a simple 25ms delay between sending each byte seems to do the trick.